### PR TITLE
Show track volume regardless of automation mode

### DIFF
--- a/reaper_csurf_integrator/control_surface_Reaper_actions.h
+++ b/reaper_csurf_integrator/control_surface_Reaper_actions.h
@@ -1523,7 +1523,9 @@ public:
         if(MediaTrack* track = context->GetTrack())
         {
             char trackVolume[128];
-            snprintf(trackVolume, sizeof(trackVolume), "%7.2lf", VAL2DB(DAW::GetMediaTrackInfo_Value(track, "D_VOL")));
+            double vol, pan;
+            DAW::GetTrackUIVolPan(track, &vol, &pan);
+            snprintf(trackVolume, sizeof(trackVolume), "%7.2lf", VAL2DB(vol));
             context->UpdateWidgetValue(string(trackVolume));
         }
         else


### PR DESCRIPTION
Previously, was only showing track volume when in trim mode. With this change, track volume will be displayed regardless of current track automation mode.